### PR TITLE
add a better regex for email validation

### DIFF
--- a/assets/js/instant-comment-validation.js
+++ b/assets/js/instant-comment-validation.js
@@ -3,6 +3,11 @@
  * http://wordpress.org/plugins/instant-comment-validation/
  * Copyright (c) 2014 Mrinal Kanti Roy; License: GPLv2 or later
 ---------------------------------------------------------*/
+jQuery.validator.addMethod("better_email", function(value, element) {
+  // a better (but not 100% perfect) email validation. RegEx via http://stackoverflow.com/a/2507043
+  return this.optional( element ) || /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/.test( value );
+}, 'Please enter a valid email address.');
+
 jQuery(document).ready(function($) {
 	$('#commentform').validate({	 
 		rules: {
@@ -12,7 +17,7 @@ jQuery(document).ready(function($) {
 		  },		 
 		  email: {
 			required: true,
-			email: true
+			better_email: true
 		  },
 		  comment: {
 			required: true,


### PR DESCRIPTION
The email validation out of the box for jQuery Validation is not that great. It allows `email@example` as a valid address. This change basically requires a `.` and a TLD of 2 to 4 characters to be considered valid. It's still not 100% perfect, there are technically a lot of weird email possibilities that this wouldn't allow (http://en.wikipedia.org/wiki/Email_address#Valid_email_addresses) but this covers most "normal" cases. Perhaps the 2-4 character TLD isn't the best approach either since they can be longer now, but it's a reasonable assumption for now.
